### PR TITLE
Changes the .ENV varibale to INFLUX_MEASUREMENT_PV

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,7 +5,7 @@ INFLUX_PORT=8086
 INFLUX_TOKEN_WRITE=my-token
 INFLUX_ORG=my-org
 INFLUX_BUCKET=my-bucket
-INFLUX_MEASUREMENT=my-measurement
+INFLUX_MEASUREMENT_PV=my-measurement
 
 # Folder with CSV test data
 IMPORT_FOLDER=./spec/data

--- a/app/config.rb
+++ b/app/config.rb
@@ -36,7 +36,7 @@ Config =
             ENV.fetch('INFLUX_TOKEN_WRITE', nil) || ENV.fetch('INFLUX_TOKEN'),
           influx_org: ENV.fetch('INFLUX_ORG'),
           influx_bucket: ENV.fetch('INFLUX_BUCKET'),
-          influx_measurement: ENV.fetch('INFLUX_MEASUREMENT'),
+          influx_measurement: ENV.fetch('INFLUX_MEASUREMENT_PV'),
           influx_open_timeout: ENV.fetch('INFLUX_OPEN_TIMEOUT', 30).to_i,
           influx_read_timeout: ENV.fetch('INFLUX_READ_TIMEOUT', 30).to_i,
           influx_write_timeout: ENV.fetch('INFLUX_WRITE_TIMEOUT', 30).to_i,


### PR DESCRIPTION
Hi @ledermann,

after running our MQTT collector successfully for quite some time, I wanted to import some historical data as well. Unfortunately , the CSV importer fails as it is looking for the .ENV variable `INFLUX_MEASUREMENT` which has been renamed to `INFLUX_MEASUREMENT_PV`

I changed this in this pull request.

Best,
Sebastian